### PR TITLE
SDK version 0.2.0-rc.11

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,3 @@
 packages:
   - src/
-  - tools/
   - test/

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rhinestone/orchestrator-sdk",
-  "version": "0.2.0-rc.10",
+  "version": "0.2.0-rc.11",
   "description": "A TypeScript library for using the Rhinestone Orchestrator",
   "author": {
     "name": "Rhinestone",


### PR DESCRIPTION
Bumped version due to unmatched github version and npm version due to `unpublish` making `rc.10` unusable.